### PR TITLE
Fix competitions API to use the correct S3 JSON filename.

### DIFF
--- a/src/controllers/competitionsController.ts
+++ b/src/controllers/competitionsController.ts
@@ -1,7 +1,9 @@
 import { Request, Response } from 'express';
 import axios from 'axios';
 
-const COMPS_S3_URL = 'https://sci-temporary-bucket.s3.us-west-2.amazonaws.com/competition.json';
+const COMPS_S3_URL =
+  'https://sci-temporary-bucket.s3.us-west-2.amazonaws.com/competitions.json';
+
 const competitions = async (req: Request, res: Response): Promise<void> => {
   try {
     const response = await axios.get(COMPS_S3_URL);

--- a/tests/unit/controllers/competitionsController.test.ts
+++ b/tests/unit/controllers/competitionsController.test.ts
@@ -18,7 +18,7 @@ describe('competitionsController', () => {
 
     await competitions(mockRequest, mockResponse);
 
-    expect(axios.get).toHaveBeenCalledWith('https://sci-temporary-bucket.s3.us-west-2.amazonaws.com/competition.json');
+    expect(axios.get).toHaveBeenCalledWith('https://sci-temporary-bucket.s3.us-west-2.amazonaws.com/competitions.json');
     expect(mockResponse.json).toHaveBeenCalledWith(mockData);
   });
 


### PR DESCRIPTION
Point the backend competitions controller at competitions.json so it matches the public bucket file used by the frontend.